### PR TITLE
Two fixes from Tessares

### DIFF
--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -161,10 +161,9 @@ u64 *find_next_key(){
 
 	struct mp_var *var = find_mp_var(var_name);
 	free(var_name);
-/*
 	if(!var || var->mptcp_subtype != MP_CAPABLE_SUBTYPE){
 		return NULL;
-	}*/
+	}
 	return (u64*)var->value;
 }
 

--- a/gtests/net/packetdrill/parser.y
+++ b/gtests/net/packetdrill/parser.y
@@ -1215,7 +1215,7 @@ seq
 	if (!is_valid_u16($5)) {
 		semantic_error("TCP payload size out of range");
 	}
-	if ($3 != ($1 +$5)) {
+	if ( ($3 & 0xFFFFFFFF) != ( ($1 +$5) &0xFFFFFFFF ) ) {
 		semantic_error("inconsistent TCP sequence numbers and "
 			       "payload size");
 	}

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -208,7 +208,7 @@ static bool is_equals_tuple_socket_and_packet(struct socket *socket,
 {
 	//TODO check all 5-tuple ([IP,port] dst/src & protocol), will be
 	//necessary when multiple interface support will be implemented
-	return is_equal_port(socket->live.local.port, packet->tcp->src_port) &&
+	return packet->tcp && is_equal_port(socket->live.local.port, packet->tcp->src_port) &&
 		   is_equal_port(socket->live.remote.port, packet->tcp->dst_port);
 }
 
@@ -223,7 +223,7 @@ static bool is_equals_tuple_socket_and_packet_reversed_ports(struct socket *sock
 {
 	//TODO check IP too, will be necessary when multiple interface support
 	//will be implemented.
-	return is_equal_port(socket->live.local.port, packet->tcp->dst_port) &&
+	return packet->tcp && is_equal_port(socket->live.local.port, packet->tcp->dst_port) &&
 			is_equal_port(socket->live.remote.port, packet->tcp->src_port);
 }
 
@@ -236,7 +236,7 @@ struct socket *find_socket_matching_packet_tuple_reversed_ports(struct state *st
 static bool socket_remote_port_equals_packet_dst_port(struct socket *socket,
 		const struct packet *packet)
 {
-	return is_equal_port(socket->live.remote.port, packet->tcp->dst_port);
+	return packet->tcp && is_equal_port(socket->live.remote.port, packet->tcp->dst_port);
 }
 
 struct socket *find_corresponding_socket_remote_port(struct state *state,


### PR DESCRIPTION
Hi Christoph,

Here are two additional fixes from Tessares:
- allow wraparound in TCP (more a non supported feature of Packetdrill)
- fix two sources of SIGSEGV with MPTCP (no mp_capable while expected) and TCP (receiving non-TCP packets while waiting for a TCP one).